### PR TITLE
fix hard-coded field name for MathExpr

### DIFF
--- a/jvm/logical-plan/src/main/kotlin/Expressions.kt
+++ b/jvm/logical-plan/src/main/kotlin/Expressions.kt
@@ -213,7 +213,7 @@ abstract class MathExpr(name: String, op: String, l: LogicalExpr, r: LogicalExpr
     BinaryExpr(name, op, l, r) {
 
   override fun toField(input: LogicalPlan): Field {
-    return Field("mult", l.toField(input).dataType)
+    return Field(name, l.toField(input).dataType)
   }
 }
 


### PR DESCRIPTION
Fix hard-coded field name for MathExpr.